### PR TITLE
デプロイ時のスクリプトの修正

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -70,4 +70,4 @@ jobs:
           aws s3 sync ${{ secrets.CONFIG_URI }} config
       - name: Deploy
         if: startsWith(github.ref, 'refs/heads/main')
-        run: npm run deploy:prod --role-arn ${{ secrets.AWS_DEPLOY_ROLE }} 
+        run: npm run deploy:prod -- --role-arn ${{ secrets.AWS_DEPLOY_ROLE }} 


### PR DESCRIPTION
npm経由でデプロイ時のスクリプトを起動する際に、コマンドラインパラメータに「--」をつけ忘れていたため、cdk deployコマンドにパラメータが渡っていなかった点を修正。