### PR TITLE
jestのワーカー数を指定する

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
-  }
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  maxWorkers: 10,
 };


### PR DESCRIPTION
jestのワーカー数を指定しない場合、github actions等の上でのカバレッジ率が安定しないことがあるため、明に指定するようにする。