### PR TITLE
Update Actions to resolve Node 20 deprecation warning

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -15,10 +15,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from `v4` to `v6` in CI workflow.
- Update `aws-actions/configure-aws-credentials` from `v4` to `v6`.
- Remove Node.js 20 deprecation warnings by moving to Node 24-compatible action versions.

## Test plan
- [x] Confirm GitHub Actions workflow runs on this branch.
- [x] Verify the warning `Node.js 20 actions are deprecated` no longer appears.

Made with [Cursor](https://cursor.com)