### PR TITLE
Update engine constraints for Node and npm compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,10 @@
         "ts-node": "^10.9.2",
         "typescript": "~5.3.3",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": "^24.0.0",
+        "npm": "^11.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "bin": {
     "ses_to_slack": "bin/ses_to_slack.js"
   },
+  "engines": {
+    "node": "^24.0.0",
+    "npm": "^11.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",


### PR DESCRIPTION
## Summary
- Add `engines` constraints to `package.json` to declare supported Node and npm major versions.
- Mirror the same `engines` declaration in `package-lock.json` to keep metadata consistent.
- Align project runtime expectations with existing Node 24 usage in local and CI environments.

## Test plan
- [x] Confirm `git diff main...HEAD` only includes engine metadata updates.
- [x] Run `npm ci --dry-run` on Node 24 / npm 11 environment.
- [x] Verify GitHub Actions build passes on this branch.


Made with [Cursor](https://cursor.com)