### PR TITLE
Update TypeScript build output configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,10 +22,16 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "outDir": "./dist"
   },
   "exclude": [
     "node_modules",
-    "cdk.out"
+    "cdk.out",
+    "dist"
+  ],
+  "include": [
+    "bin/**/*.ts",
+    "lib/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- route TypeScript compiler outputs to `dist` via `outDir`
- exclude `dist` from compilation inputs to avoid recursive artifact processing
- limit build targets to `bin/**/*.ts` and `lib/**/*.ts` so test/vitest type packages are excluded from production build

## Test plan
- [x] `npm run build`
- [x] confirm outputs are generated under `dist/bin` and `dist/lib`

Made with [Cursor](https://cursor.com)