### PR TITLE
Update Dependabot version update behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 0
+      semver-patch-days: 0


### PR DESCRIPTION
## Summary
- Allow Dependabot to create PRs for major version updates (remove major ignore rule).
- Limit concurrently open Dependabot version update PRs to five.
- Prioritize minor/patch updates by adding cooldown settings that delay major updates.

## Test plan
- [x] Validate `.github/dependabot.yml` syntax after update.
- [x] Confirm `ignore` for `semver-major` is removed.
- [x] Confirm `open-pull-requests-limit` is set to `5`.
- [x] Confirm `cooldown` delays major updates and keeps minor/patch immediate.

Made with [Cursor](https://cursor.com)