### PR TITLE
Dependabot の cooldown と依存関係グループ化を設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,32 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       semver-major-days: 7
-      semver-minor-days: 0
-      semver-patch-days: 0
+      semver-minor-days: 1
+      semver-patch-days: 1
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      aws-cdk:
+        patterns:
+          - "aws-cdk-lib"
+          - "aws-cdk"
+          - "@aws-cdk/*"
+          - "constructs"
+        update-types:
+          - "minor"
+          - "patch"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+        update-types:
+          - "minor"
+          - "patch"
+      types:
+        dependency-type: "development"
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- マイナー・パッチ更新の cooldown を 1 日に変更（major は 7 日のまま）
- `@aws-sdk/*` を `aws-sdk` グループにまとめる
- `aws-cdk` / `vitest` / `@types/*`（development）の minor・patch 更新もグループ化し、PR 数を削減

## Test plan
- [ ] `.github/dependabot.yml` の YAML 構文が正しいことを確認
- [ ] マージ後、次回の Dependabot 実行でグループ化された PR が作成されることを確認


Made with [Cursor](https://cursor.com)